### PR TITLE
Adding Pipeline To Create New Release

### DIFF
--- a/.github/workflows/new-content-build-publish.yaml
+++ b/.github/workflows/new-content-build-publish.yaml
@@ -1,0 +1,43 @@
+name: Create New Release For Updated Content
+on:
+  - repository_dispatch
+  - workflow_dispatch 
+
+jobs:
+  get-latest-tag:
+    runs-on: ubuntu-latest
+    outputs:
+      current-tag: ${{ steps.previoustag.outputs.tag}}
+      next-tag: ${{ steps.nextversion.outputs.v_patch}}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Get previous tags
+        id: previoustag
+        uses: "WyriHaximus/github-action-get-previous-tag@v1"
+      - name: Get Next Patch Version
+        id: nextversion
+        uses: "WyriHaximus/github-action-next-semvers@v1"
+        with:
+          version: ${{ steps.previoustag.outputs.tag }}
+          type: patch
+
+  build-and-deploy-new-content:
+    runs-on: ubuntu-latest
+    needs: get-latest-tag
+    permissions:
+      packages: write
+      contents: write 
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          ref: ${{ needs.get-latest-tag.outputs.current-tag }}
+      - name: Create a Release
+        uses: elgohr/Github-Release-Action@v5
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          title: ${{ needs.get-latest-tag.outputs.next-tag }}
+          tag: ${{ needs.get-latest-tag.outputs.next-tag }}


### PR DESCRIPTION
Pipeline with only repository and workflow dispatch enabled, so that it can be manually triggered to create a new release based on the latest version.  A new release will trigger a new build with a new version number, to pull in any content updates.
